### PR TITLE
feature: update lobaro preset with exclusive dom/dow

### DIFF
--- a/lib/fieldCheckers/dayOfMonthChecker.js
+++ b/lib/fieldCheckers/dayOfMonthChecker.js
@@ -27,6 +27,16 @@ const checkDaysOfMonth = (cronData, options) => {
             `Cannot specify both daysOfMonth and daysOfWeek field when mustHaveBlankDayField option is enabled.`,
         ]);
     }
+    // lobaro-specific: allow '*' in daysOfMonth or daysOfWeek for mustHaveBlankDayField
+    if (options.lobaroMustHaveBlankDayField &&
+        cronData.daysOfMonth !== '?' &&
+        cronData.daysOfMonth !== '*' &&
+        cronData.daysOfWeek !== '?' &&
+        cronData.daysOfWeek !== '*') {
+        return (0, result_1.err)([
+            `Cannot specify both daysOfMonth and daysOfWeek field when lobaroMustHaveBlankDayField option is enabled.`,
+        ]);
+    }
     // Based on this implementation logic:
     // https://github.com/quartz-scheduler/quartz/blob/1e0ed76c5c141597eccd76e44583557729b5a7cb/quartz-core/src/main/java/org/quartz/CronExpression.java#L473
     // For Lobaro CRONs, LW is allowed in lists

--- a/lib/fieldCheckers/dayOfWeekChecker.js
+++ b/lib/fieldCheckers/dayOfWeekChecker.js
@@ -26,6 +26,16 @@ const checkDaysOfWeek = (cronData, options) => {
             `Cannot specify both daysOfMonth and daysOfWeek field when mustHaveBlankDayField option is enabled.`,
         ]);
     }
+    // lobaro-specific: allow '*' in daysOfMonth or daysOfWeek for mustHaveBlankDayField
+    if (options.lobaroMustHaveBlankDayField &&
+        cronData.daysOfMonth !== '?' &&
+        cronData.daysOfMonth !== '*' &&
+        cronData.daysOfWeek !== '?' &&
+        cronData.daysOfWeek !== '*') {
+        return (0, result_1.err)([
+            `Cannot specify both daysOfMonth and daysOfWeek field when lobaroMustHaveBlankDayField option is enabled.`,
+        ]);
+    }
     // Based on this implementation logic:
     // https://github.com/quartz-scheduler/quartz/blob/1e0ed76c5c141597eccd76e44583557729b5a7cb/quartz-core/src/main/java/org/quartz/CronExpression.java#L477
     if (options.useLastDayOfWeek &&

--- a/lib/option.js
+++ b/lib/option.js
@@ -204,6 +204,7 @@ function presetToOptionsSchema(preset) {
         useNearestWeekday: yup.boolean(),
         lobaroUseListOfNearestWeekdays: yup.boolean(),
         lobaroUseHashValue: yup.boolean(),
+        lobaroMustHaveBlankDayField: yup.boolean(),
         useNthWeekdayOfMonth: yup.boolean(),
         seconds: yup
             .object({

--- a/lib/presets.d.ts
+++ b/lib/presets.d.ts
@@ -8,6 +8,8 @@ declare const _default: ({
         useBlankDay: boolean;
         allowOnlyOneBlankDayField: boolean;
         mustHaveBlankDayField: boolean;
+        lobaroMustHaveBlankDayField: boolean;
+        lobaroUseHashValue: boolean;
         useLastDayOfMonth: boolean;
         useLastDayOfWeek: boolean;
         useNearestWeekday: boolean;
@@ -112,6 +114,8 @@ declare const _default: ({
             lowerLimit?: undefined;
             upperLimit?: undefined;
         };
+        lobaroMustHaveBlankDayField?: undefined;
+        lobaroUseHashValue?: undefined;
         lobaroUseListOfNearestWeekdays?: undefined;
     };
 } | {
@@ -128,6 +132,8 @@ declare const _default: ({
         useLastDayOfWeek: boolean;
         useNearestWeekday: boolean;
         lobaroUseListOfNearestWeekdays: boolean;
+        lobaroUseHashValue: boolean;
+        lobaroMustHaveBlankDayField: boolean;
         useNthWeekdayOfMonth: boolean;
         seconds: {
             minValue: number;

--- a/lib/presets.js
+++ b/lib/presets.js
@@ -147,7 +147,7 @@ exports.default = [
             useAliases: false,
             useBlankDay: true,
             allowOnlyOneBlankDayField: false,
-            mustHaveBlankDayField: false,
+            mustHaveBlankDayField: true,
             useLastDayOfMonth: true,
             useLastDayOfWeek: true,
             useNearestWeekday: true,

--- a/lib/presets.js
+++ b/lib/presets.js
@@ -12,6 +12,8 @@ exports.default = [
             useBlankDay: false,
             allowOnlyOneBlankDayField: false,
             mustHaveBlankDayField: false,
+            lobaroMustHaveBlankDayField: false,
+            lobaroUseHashValue: false,
             useLastDayOfMonth: false,
             useLastDayOfWeek: false,
             useNearestWeekday: false,
@@ -61,7 +63,6 @@ exports.default = [
             useLastDayOfMonth: true,
             useLastDayOfWeek: true,
             useNearestWeekday: true,
-            lobaroUseListOfNearestWeekdays: false,
             useNthWeekdayOfMonth: true,
             seconds: {
                 minValue: 0,
@@ -152,6 +153,8 @@ exports.default = [
             useLastDayOfWeek: true,
             useNearestWeekday: true,
             lobaroUseListOfNearestWeekdays: true,
+            lobaroUseHashValue: true,
+            lobaroMustHaveBlankDayField: false,
             useNthWeekdayOfMonth: false,
             seconds: {
                 minValue: 0,

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -33,6 +33,7 @@ declare type ExtendWildcards = {
     lobaroUseListOfNearestWeekdays?: boolean;
     lobaroUseHashValue?: boolean;
     useNthWeekdayOfMonth?: boolean;
+    lobaroMustHaveBlankDayField?: boolean;
 };
 export declare type OptionPreset = {
     presetId: string;

--- a/src/fieldCheckers/dayOfMonthChecker.ts
+++ b/src/fieldCheckers/dayOfMonthChecker.ts
@@ -37,8 +37,10 @@ const checkDaysOfMonth = (
   // lobaro-specific: allow '*' in daysOfMonth or daysOfWeek for mustHaveBlankDayField
   if (
     options.lobaroMustHaveBlankDayField &&
-    ((cronData.daysOfMonth !== '?' && cronData.daysOfMonth !== '*') &&
-    (cronData.daysOfWeek !== '?' && cronData.daysOfWeek !== '*'))
+    cronData.daysOfMonth !== '?' &&
+    cronData.daysOfMonth !== '*' &&
+    cronData.daysOfWeek !== '?' &&
+    cronData.daysOfWeek !== '*'
   ) {
     return err([
       `Cannot specify both daysOfMonth and daysOfWeek field when lobaroMustHaveBlankDayField option is enabled.`,

--- a/src/fieldCheckers/dayOfMonthChecker.ts
+++ b/src/fieldCheckers/dayOfMonthChecker.ts
@@ -34,6 +34,17 @@ const checkDaysOfMonth = (
     ])
   }
 
+  // lobaro-specific: allow '*' in daysOfMonth or daysOfWeek for mustHaveBlankDayField
+  if (
+    options.lobaroMustHaveBlankDayField &&
+    ((cronData.daysOfMonth !== '?' && cronData.daysOfMonth !== '*') &&
+    (cronData.daysOfWeek !== '?' && cronData.daysOfWeek !== '*'))
+  ) {
+    return err([
+      `Cannot specify both daysOfMonth and daysOfWeek field when lobaroMustHaveBlankDayField option is enabled.`,
+    ])
+  }
+
   // Based on this implementation logic:
   // https://github.com/quartz-scheduler/quartz/blob/1e0ed76c5c141597eccd76e44583557729b5a7cb/quartz-core/src/main/java/org/quartz/CronExpression.java#L473
   // For Lobaro CRONs, LW is allowed in lists

--- a/src/fieldCheckers/dayOfWeekChecker.ts
+++ b/src/fieldCheckers/dayOfWeekChecker.ts
@@ -33,6 +33,17 @@ const checkDaysOfWeek = (
     ])
   }
 
+  // lobaro-specific: allow '*' in daysOfMonth or daysOfWeek for mustHaveBlankDayField
+  if (
+    options.lobaroMustHaveBlankDayField &&
+    (cronData.daysOfMonth !== '?' && cronData.daysOfMonth !== '*') &&
+    (cronData.daysOfWeek !== '?' && cronData.daysOfWeek !== '*')
+  ) {
+    return err([
+      `Cannot specify both daysOfMonth and daysOfWeek field when lobaroMustHaveBlankDayField option is enabled.`,
+    ])
+  }
+
   // Based on this implementation logic:
   // https://github.com/quartz-scheduler/quartz/blob/1e0ed76c5c141597eccd76e44583557729b5a7cb/quartz-core/src/main/java/org/quartz/CronExpression.java#L477
   if (

--- a/src/fieldCheckers/dayOfWeekChecker.ts
+++ b/src/fieldCheckers/dayOfWeekChecker.ts
@@ -36,8 +36,10 @@ const checkDaysOfWeek = (
   // lobaro-specific: allow '*' in daysOfMonth or daysOfWeek for mustHaveBlankDayField
   if (
     options.lobaroMustHaveBlankDayField &&
-    (cronData.daysOfMonth !== '?' && cronData.daysOfMonth !== '*') &&
-    (cronData.daysOfWeek !== '?' && cronData.daysOfWeek !== '*')
+    cronData.daysOfMonth !== '?' &&
+    cronData.daysOfMonth !== '*' &&
+    cronData.daysOfWeek !== '?' &&
+    cronData.daysOfWeek !== '*'
   ) {
     return err([
       `Cannot specify both daysOfMonth and daysOfWeek field when lobaroMustHaveBlankDayField option is enabled.`,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -866,4 +866,84 @@ describe('Test cron validation', () => {
 
     expect(cron('5-7,8-9,10-20,21-23 * * * *', { override: { allowStepping: false } }).isValid()).toBeFalsy()
   })
+
+  it("Test lobaro mustHaveBlankDayField option", () => {
+    expect(cron('* * * * *', {
+      override: {
+        useBlankDay: true,
+        lobaroMustHaveBlankDayField: true,
+      },
+    }).isValid()).toBeTruthy()
+
+    expect(cron('* * 9 * *', {
+      override: {
+        useBlankDay: true,
+        lobaroMustHaveBlankDayField: true,
+      },
+    }).isValid()).toBeTruthy()
+
+    expect(cron('* * 9 * ?', {
+      override: {
+        useBlankDay: true,
+        lobaroMustHaveBlankDayField: true,
+      },
+    }).isValid()).toBeTruthy()
+
+    expect(cron('* * ? * 1', {
+      override: {
+        useBlankDay: true,
+        lobaroMustHaveBlankDayField: true,
+      },
+    }).isValid()).toBeTruthy()
+
+    expect(cron('* * * * 1', {
+      override: {
+        useBlankDay: true,
+        lobaroMustHaveBlankDayField: true,
+      },
+    }).isValid()).toBeTruthy()
+
+    expect(cron('* * 9 * 1', {
+      override: {
+        useBlankDay: true,
+        lobaroMustHaveBlankDayField: true,
+      },
+    }).isValid()).toBeFalsy()
+
+    // without option
+    expect(cron('* * * * *').isValid()).toBeTruthy()
+
+    expect(cron('* * 9 * *').isValid()).toBeTruthy()
+    expect(cron('* * 9 * *', {
+      override: {
+        mustHaveBlankDayField: true
+      }
+    }).isValid()).toBeFalsy()
+
+    expect(cron('* * 9 * ?', {
+      override: {
+        useBlankDay: true,
+      },
+    }).isValid()).toBeTruthy()
+
+    expect(cron('* * ? * 1', {
+      override: {
+        useBlankDay: true,
+      },
+    }).isValid()).toBeTruthy()
+
+    expect(cron('* * * * 1').isValid()).toBeTruthy()
+    expect(cron('* * * * 1', {
+      override: {
+        mustHaveBlankDayField: true,
+      },
+    }).isValid()).toBeFalsy()
+
+    expect(cron('* * 9 * 1', {
+      override: {
+        useBlankDay: true,
+        lobaroMustHaveBlankDayField: true,
+      },
+    }).isValid()).toBeFalsy()
+  })
 })

--- a/src/option.ts
+++ b/src/option.ts
@@ -185,8 +185,9 @@ function presetToOptionsSchema(preset: OptionPreset) {
     useLastDayOfWeek: yup.boolean(),
     useNearestWeekday: yup.boolean(),
     lobaroUseListOfNearestWeekdays: yup.boolean(),
-        lobaroUseHashValue: yup.boolean(),
-        useNthWeekdayOfMonth: yup.boolean(),
+    lobaroUseHashValue: yup.boolean(),
+    lobaroMustHaveBlankDayField: yup.boolean(),
+    useNthWeekdayOfMonth: yup.boolean(),
         seconds: yup
           .object({
             lowerLimit: yup

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -10,6 +10,8 @@ export default [
       useBlankDay: false,
       allowOnlyOneBlankDayField: false,
       mustHaveBlankDayField: false,
+      lobaroMustHaveBlankDayField: false,
+      lobaroUseHashValue: false,
       useLastDayOfMonth: false,
       useLastDayOfWeek: false,
       useNearestWeekday: false,
@@ -59,7 +61,6 @@ export default [
       useLastDayOfMonth: true,
       useLastDayOfWeek: true,
       useNearestWeekday: true,
-      lobaroUseListOfNearestWeekdays: false,
       useNthWeekdayOfMonth: true,
       seconds: {
         minValue: 0,
@@ -150,6 +151,8 @@ export default [
       useLastDayOfWeek: true,
       useNearestWeekday: true,
       lobaroUseListOfNearestWeekdays: true,
+      lobaroUseHashValue: true,
+      lobaroMustHaveBlankDayField: false,
       useNthWeekdayOfMonth: false,
       seconds: {
         minValue: 0,

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -145,7 +145,7 @@ export default [
       useAliases: false,
       useBlankDay: true,
       allowOnlyOneBlankDayField: false,
-      mustHaveBlankDayField: false,
+      mustHaveBlankDayField: true,
       useLastDayOfMonth: true,
       useLastDayOfWeek: true,
       useNearestWeekday: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ type ExtendWildcards = {
   lobaroUseListOfNearestWeekdays?: boolean
   lobaroUseHashValue?: boolean
   useNthWeekdayOfMonth?: boolean
+  lobaroMustHaveBlankDayField?: boolean
 }
 
 export type OptionPreset = {


### PR DESCRIPTION
Needed for newer devices, won't validate a cron with both DOM and DOW set.
Adding a separate validator for it, as we count '*' as a blank day as well.

Related to lobaro/lobaro-backend#935